### PR TITLE
Change traefik labels to work with the v2 and v3 rule matcher syntax

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,8 +46,8 @@ docker_registry_storage_delete_enabled: false
 # To inject your own other container labels, see `docker_registry_container_labels_additional_labels`.
 docker_registry_container_labels_traefik_enabled: true
 docker_registry_container_labels_traefik_docker_network: ''
-docker_registry_container_labels_traefik_rule_public: "Host(`{{ docker_registry_hostname }}`) && Method(`GET`, `HEAD`)"
-docker_registry_container_labels_traefik_rule_private: "Host(`{{ docker_registry_hostname }}`) && Method(`POST`, `PUT`, `DELETE`, `PATCH`)"
+docker_registry_container_labels_traefik_rule_public: "Host(`{{ docker_registry_hostname }}`) && (Method(`GET`) || Method(`HEAD`))"
+docker_registry_container_labels_traefik_rule_private: "Host(`{{ docker_registry_hostname }}`) && (Method(`POST`) || Method(`PUT`) || Method(`DELETE`) || Method(`PATCH`))"
 docker_registry_container_labels_traefik_entrypoints: web-secure
 docker_registry_container_labels_traefik_tls: "{{ docker_registry_container_labels_traefik_entrypoints != 'web' }}"
 docker_registry_container_labels_traefik_tls_certResolver: default  # noqa var-naming


### PR DESCRIPTION
https://doc.traefik.io/traefik/v3.0/migration/v2-to-v3-details/#new-v3-syntax-notable-changes